### PR TITLE
button + touch problem

### DIFF
--- a/src/skin_theme.c
+++ b/src/skin_theme.c
@@ -152,7 +152,7 @@ void wz_skin_draw_button(WZ_THEME* theme, float x, float y, float w, float h, AL
 	pad.top = 0;
 	pad.bottom = 0;
 
-	if(style & WZ_STYLE_FOCUSED)
+	if( (style & WZ_STYLE_FOCUSED) && !(style & WZ_STYLE_DOWN) )
 	{
 		button_col = wz_scale_color(def->color1, 1.25);
 	}

--- a/src/skin_theme.c
+++ b/src/skin_theme.c
@@ -155,7 +155,7 @@ void wz_skin_draw_button(WZ_THEME* theme, float x, float y, float w, float h, AL
 #if defined(ALLEGRO_ANDROID) || defined(ALLEGRO_IPHONE)
 	if( (style & WZ_STYLE_FOCUSED) && !(style & WZ_STYLE_DOWN) )
 #else
-        if( (style & WZ_STYLE_FOCUSED) )
+	if( (style & WZ_STYLE_FOCUSED) )
 #endif
 	{
 		button_col = wz_scale_color(def->color1, 1.25);

--- a/src/skin_theme.c
+++ b/src/skin_theme.c
@@ -152,7 +152,11 @@ void wz_skin_draw_button(WZ_THEME* theme, float x, float y, float w, float h, AL
 	pad.top = 0;
 	pad.bottom = 0;
 
+#if defined(ALLEGRO_ANDROID) || defined(ALLEGRO_IPHONE)
 	if( (style & WZ_STYLE_FOCUSED) && !(style & WZ_STYLE_DOWN) )
+#else
+        if( (style & WZ_STYLE_FOCUSED) )
+#endif
 	{
 		button_col = wz_scale_color(def->color1, 1.25);
 	}

--- a/src/widgets/scroll.c
+++ b/src/widgets/scroll.c
@@ -34,13 +34,13 @@ static int set_scroll_pos(WZ_SCROLL* scl, float x, float y)
 	{
 		float max_size = 0.9f * wgt->h;
 		float slider_size = scl->slider_size > max_size ? max_size : scl->slider_size;
-		fraction = ((float)(y - wgt->y - slider_size / 2)) / ((float)wgt->h - slider_size);
+		fraction = ((float)(y - wgt->local_y - slider_size / 2)) / ((float)wgt->h - slider_size);
 	}
 	else
 	{
 		float max_size = 0.9f * wgt->w;
 		float slider_size = scl->slider_size > max_size ? max_size : scl->slider_size;
-		fraction = ((float)(x - wgt->x - slider_size / 2)) / ((float)wgt->w - slider_size);
+		fraction = ((float)(x - wgt->local_x - slider_size / 2)) / ((float)wgt->w - slider_size);
 	}
 
 	old_pos = scl->cur_pos;


### PR DESCRIPTION
In touch devices, pressing on a button (particularly a toggle button) that is "up" will show it as focused instead of down (you need to press it a second time to see it down, although it registers the button down event the first time).
Here's what I did to "fix" it, but probably there is a better way...
